### PR TITLE
Implement keyboard shortcuts for editing operations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { MainLayout } from './components/layout/MainLayout';
 import { CommandList } from './components/skit/CommandList';
 import { CommandEditor } from './components/skit/CommandEditor';
@@ -24,6 +25,7 @@ import './App.css';
 
 function App() {
   const { loadCommandsYaml, loadSkits, projectPath } = useSkitStore();
+  useKeyboardShortcuts();
 
   useEffect(() => {
     const loadInitialData = async () => {

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+import { useSkitStore } from '../store/skitStore';
+
+export function useKeyboardShortcuts() {
+  const {
+    selectedCommandIds,
+    removeCommand,
+    duplicateCommand,
+    copySelectedCommands,
+    cutSelectedCommands,
+    pasteCommandsFromClipboard,
+    undo,
+    redo,
+  } = useSkitStore();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      const meta = event.metaKey || event.ctrlKey;
+
+      if (meta && key === 'c') {
+        event.preventDefault();
+        copySelectedCommands();
+      }
+
+      if (meta && key === 'x') {
+        event.preventDefault();
+        cutSelectedCommands();
+      }
+
+      if (meta && key === 'v') {
+        event.preventDefault();
+        pasteCommandsFromClipboard();
+      }
+
+      if (key === 'delete' || key === 'backspace') {
+        if (selectedCommandIds.length > 0) {
+          event.preventDefault();
+          removeCommand(selectedCommandIds[0]);
+        }
+      }
+
+      if (meta && key === 'd') {
+        if (selectedCommandIds.length > 0) {
+          event.preventDefault();
+          duplicateCommand(selectedCommandIds[0]);
+        }
+      }
+
+      if (meta && !event.shiftKey && key === 'z') {
+        event.preventDefault();
+        undo();
+      }
+
+      if (meta && (key === 'y' || (event.shiftKey && key === 'z'))) {
+        event.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    selectedCommandIds,
+    removeCommand,
+    duplicateCommand,
+    copySelectedCommands,
+    cutSelectedCommands,
+    pasteCommandsFromClipboard,
+    undo,
+    redo,
+  ]);
+}


### PR DESCRIPTION
## Summary
- add `useKeyboardShortcuts` hook for copy, cut, paste, delete, duplicate, undo and redo
- invoke the new hook in `App.tsx`

## Testing
- `npx playwright test --reporter=list` *(fails: browsers not installed)*